### PR TITLE
Added 'macs' DevScanner argument

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -56,3 +56,10 @@ this readme :
     ...
     <T temp: 20.4 humidity: 71> (c6:97:89:d6:c8:09)
     c6:97:89:d6:c8:09 -> 20.4
+
+If your device is shown but not returned by DevScanner, it wasn't identified as
+a SwitchBot meter. In this case, pass the MAC address to DevScanner, e.g.:
+
+.. code:: python
+
+    DevScanner(macs=['c6:97:89:d6:c8:09'])


### PR DESCRIPTION
Hi, my meter was shown but DevScanner didn't return it. I found out the model identification done in the set_mac function didn't work with my device. This has also been reported [by someone else after a firmware update](https://forums.raspberrypi.com/viewtopic.php?t=342086).

I tried to find another way to identify the device, but apparently bluepy isn't giving much information, not even the device name, even if with bluetoothctl I can see a lot of information, including the SERVICE_UUID used in your code.

In the end I solved it by allowing to pass a list of MAC addresses to DevScanner, which overrides model identification.